### PR TITLE
refresh staff when subject and group is selected

### DIFF
--- a/UniTimetable.php
+++ b/UniTimetable.php
@@ -26,6 +26,7 @@ function utt_activate(){
     $holidaysTable=$wpdb->prefix."utt_holidays";
     $eventsTable=$wpdb->prefix."utt_events";
     $lecturesView=$wpdb->prefix."utt_lectures_view";
+    $teacherSubGrp=$wpdb->prefix."utt_teacher_sub_grp";
     $charset_collate = $wpdb->get_charset_collate();
     
     //create utt tables
@@ -74,7 +75,33 @@ function utt_activate(){
             ENGINE = InnoDB
             $charset_collate;";
     dbDelta($sql);
-    
+    $sql="CREATE TABLE IF NOT EXISTS `$teacherSubGrp`(
+            teachersubgrpID int UNSIGNED NOT NULL AUTO_INCREMENT,
+            teacherID smallint UNSIGNED NOT NULL COMMENT 'FKey from teachers table',
+            KEY `fk_teachers_id` (teacherID),
+            CONSTRAINT `fk_teacher_id`
+            FOREIGN KEY (teacherID)
+            REFERENCES `$teachersTable` (teacherID)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE,
+            subjectID int UNSIGNED NOT NULL COMMENT 'FKey from Subjects',
+            KEY `fk_Teachers_Subject1_idx` (subjectID),
+            CONSTRAINT `fk_Teachers_Subjects`
+            FOREIGN KEY (subjectID)
+            REFERENCES `$subjectsTable` (subjectID)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE,
+            KEY `fk_Teachers_Group1_idx` (groupID),
+            groupID int UNSIGNED NOT NULL COMMENT 'FKey from Groups',
+            CONSTRAINT `fk_Teachers_Groups1`
+            FOREIGN KEY (groupID)
+            REFERENCES `$groupsTable` (groupID)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE,
+            PRIMARY KEY  (teachersubgrpID, teacherID, subjectID, groupID))
+            ENGINE = InnoDB
+            $charset_collate;";
+    dbDelta($sql);
     $sql="CREATE TABLE IF NOT EXISTS `$teachersTable` (
             teacherID smallint UNSIGNED NOT NULL AUTO_INCREMENT,
             surname varchar(35) NOT NULL COMMENT 'teacher\'s surname',
@@ -82,21 +109,6 @@ function utt_activate(){
             minWorkLoad smallint UNSIGNED NOT NULL COMMENT 'minimum workload for teacher',
             maxWorkLoad smallint UNSIGNED NOT NULL COMMENT 'maximum workload for teacher',
             assignedWorkLoad smallint UNSIGNED NOT NULL COMMENT 'actual assigned workload for teacher',
-            subjectID int UNSIGNED NOT NULL COMMENT 'FKey from Subjects',
-            KEY `fk_Teachers_Subject1_idx` (subjectID ASC),
-            CONSTRAINT `fk_Teachers_Subjects`
-            FOREIGN KEY (subjectID)
-            REFERENCES `$subjectsTable` (subjectID)
-            ON DELETE RESTRICT
-            ON UPDATE CASCADE,
-            KEY `fk_Teachers_Group1_idx` (groupID ASC),
-            groupID int UNSIGNED NOT NULL COMMENT 'FKey from Groups',
-            CONSTRAINT `fk_Teachers_Groups1`
-            FOREIGN KEY (groupID)
-            REFERENCES `$groupsTable` (groupID)
-            ON DELETE RESTRICT
-            ON UPDATE CASCADE,
-
             PRIMARY KEY  (teacherID),
             UNIQUE KEY `unique_teacher` (surname ASC, name ASC))
             ENGINE = InnoDB

--- a/UniTimetable.php
+++ b/UniTimetable.php
@@ -82,6 +82,21 @@ function utt_activate(){
             minWorkLoad smallint UNSIGNED NOT NULL COMMENT 'minimum workload for teacher',
             maxWorkLoad smallint UNSIGNED NOT NULL COMMENT 'maximum workload for teacher',
             assignedWorkLoad smallint UNSIGNED NOT NULL COMMENT 'actual assigned workload for teacher',
+            subjectID int UNSIGNED NOT NULL COMMENT 'FKey from Subjects',
+            KEY `fk_Teachers_Subject1_idx` (subjectID ASC),
+            CONSTRAINT `fk_Teachers_Subjects`
+            FOREIGN KEY (subjectID)
+            REFERENCES `$subjectsTable` (subjectID)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE,
+            KEY `fk_Teachers_Group1_idx` (groupID ASC),
+            groupID int UNSIGNED NOT NULL COMMENT 'FKey from Groups',
+            CONSTRAINT `fk_Teachers_Groups1`
+            FOREIGN KEY (groupID)
+            REFERENCES `$groupsTable` (groupID)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE,
+
             PRIMARY KEY  (teacherID),
             UNIQUE KEY `unique_teacher` (surname ASC, name ASC))
             ENGINE = InnoDB
@@ -257,20 +272,20 @@ function utt_UniTimetableMenu_create(){
     add_menu_page('UniTimeTable','UniTimeTable','manage_options',__FILE__,'utt_UniTimetable_page' );
     
     //add submenu pages to UniTimetable menu
-    $teachersPage = add_submenu_page( __FILE__, __("Insert Teacher","UniTimetable"), __("Teachers","UniTimetable"), 'manage_options',__FILE__.'_teachers', 'utt_create_teachers_page' );
-    add_action('load-'.$teachersPage, 'utt_teacher_scripts');
+    $subjectsPage = add_submenu_page( __FILE__, __("Insert Subject","UniTimetable"), __("Subjects","UniTimetable"), 'manage_options',__FILE__.'_subjects', 'utt_create_subjects_page' );
+    add_action('load-'.$subjectsPage, 'utt_subject_scripts');
     
     $periodsPage = add_submenu_page( __FILE__, __("Insert Period","UniTimetable"), __("Periods","UniTimetable"), 'manage_options',__FILE__.'_periods', 'utt_create_periods_page' );
     add_action('load-'.$periodsPage, 'utt_period_scripts');
     
-    $subjectsPage = add_submenu_page( __FILE__, __("Insert Subject","UniTimetable"), __("Subjects","UniTimetable"), 'manage_options',__FILE__.'_subjects', 'utt_create_subjects_page' );
-    add_action('load-'.$subjectsPage, 'utt_subject_scripts');
+    $groupsPage = add_submenu_page( __FILE__, __("Insert Group","UniTimetable"), __("Groups","UniTimetable"), 'manage_options',__FILE__.'_groups', 'utt_create_groups_page' );
+    add_action('load-'.$groupsPage, 'utt_group_scripts');
+    
+    $teachersPage = add_submenu_page( __FILE__, __("Insert Teacher","UniTimetable"), __("Teachers","UniTimetable"), 'manage_options',__FILE__.'_teachers', 'utt_create_teachers_page' );
+    add_action('load-'.$teachersPage, 'utt_teacher_scripts');
     
     $classroomsPage = add_submenu_page( __FILE__, __("Insert Classroom","UniTimetable"), __("Classrooms","UniTimetable"), 'manage_options',__FILE__.'_classrooms', 'utt_create_classrooms_page' );
     add_action('load-'.$classroomsPage, 'utt_classroom_scripts');
-    
-    $groupsPage = add_submenu_page( __FILE__, __("Insert Group","UniTimetable"), __("Groups","UniTimetable"), 'manage_options',__FILE__.'_groups', 'utt_create_groups_page' );
-    add_action('load-'.$groupsPage, 'utt_group_scripts');
     
     $holidaysPage = add_submenu_page( __FILE__, __("Insert Holiday","UniTimetable"), __("Holidays","UniTimetable"), 'manage_options',__FILE__.'_holidays', 'utt_create_holidays_page' );
     add_action('load-'.$holidaysPage, 'utt_holiday_scripts');

--- a/js/lectureScripts.js
+++ b/js/lectureScripts.js
@@ -169,6 +169,20 @@ function loadSubjects(selected){
       jQuery('#subjects').html(data);
    });
 }
+//load teachers when subject and group is selected
+function loadTheTeacher(){
+   subject = jQuery('#subject').val();
+   group = jQuery('#group').val();
+   //ajax data
+   var data = {
+      action: 'utt_load_teachers',
+      teacherSubject: subject,
+      teacherGroup: group
+   }
+   jQuery.get('admin-ajax.php', data, function(data){
+      jQuery('#teacher').html(data);
+   });
+}
 //load work hours when teacher is selected
 function loadWorkHours(){
    teacherName = jQuery('#teacher').val();

--- a/js/teacherScripts.js
+++ b/js/teacherScripts.js
@@ -92,6 +92,7 @@ jQuery(function ($) {
       //ajax call
       $.get('admin-ajax.php' , data, function(data){
          success = data;
+         alert(data);
          //success
          if (success == 1) {
             //insert

--- a/js/teacherScripts.js
+++ b/js/teacherScripts.js
@@ -59,6 +59,8 @@ jQuery(function ($) {
       var teacherSurName = $('#lastname').val();
       var teacherMinWork = $('#minwork').val();
       var teacherMaxWork = $('#maxwork').val();
+      var teacherSubjectID = $('#subject').val();
+      var teacherGroupID = $('#group').val();
       var regexName = /^[α-ωΑ-ΩA-Za-zΆ-Ώά-ώ0-9_\s-.\/]{0,35}$/;
       var regexSurName = /^[α-ωΑ-ΩA-Za-zΆ-Ώά-ώ0-9_\s-.\/]{3,35}$/;
       var regexHour = /^[0-9]{1,2}$/;
@@ -83,7 +85,9 @@ jQuery(function ($) {
          teacher_name: teacherName,
          teacher_surname: teacherSurName,
          teacher_min_work: teacherMinWork,
-         teacher_max_work: teacherMaxWork
+         teacher_max_work: teacherMaxWork,
+         teacher_subject_id: teacherSubjectID,
+         teacher_group_id: teacherGroupID
       };
       //ajax call
       $.get('admin-ajax.php' , data, function(data){
@@ -103,6 +107,8 @@ jQuery(function ($) {
             jQuery('#lastname').val("");
             jQuery('#minwork').val("");
             jQuery('#maxwork').val("");
+            jQuery('#subject').val("");
+            jQuery('#group').val("");
             jQuery('#teacherTitle').html(teacherStrings.insertTeacher);
             jQuery('#clearTeacherForm').html(teacherStrings.reset);
             isDirty = 0;
@@ -134,6 +140,8 @@ jQuery(function ($) {
       $('#firstname').val("");
       $('#lastname').val("");
       $('#teacherid').val(0);
+      $('#subject').val(0).change();
+      $('#group').val(0).change();
       $('#clearTeacherForm').html(teacherStrings.reset);
       $('#message').remove();
       $('#minwork').val("");

--- a/lecturesFunctions.php
+++ b/lecturesFunctions.php
@@ -274,9 +274,15 @@ add_action('wp_ajax_utt_load_teachers', 'utt_load_teachers');
 function utt_load_teachers(){
     global $wpdb;
     $teachersTable=$wpdb->prefix."utt_teachers";
+    $teacherSubGrp=$wpdb->prefix."utt_teacher_sub_grp";
     $sub=$_GET['teacherSubject'];
     $grp=$_GET['teacherGroup'];
-    $safeSql = $wpdb->prepare("SELECT * FROM $teachersTable WHERE subjectID='$sub' AND groupID='$grp';");
+
+    $safeSql = $wpdb->prepare("SELECT * FROM $teacherSubGrp WHERE subjectID='$sub' AND groupID='$grp';");
+    $teachers = $wpdb->get_row($safeSql);
+    
+
+    $safeSql = $wpdb->prepare("SELECT * FROM $teachersTable WHERE teacherID='$teachers->teacherID';");
     $teachers = $wpdb->get_results($safeSql);
     
     echo "<select name='teacher' id='teacher' class='dirty' onchange='loadWorkHours();'>";

--- a/lecturesFunctions.php
+++ b/lecturesFunctions.php
@@ -350,7 +350,7 @@ function utt_insert_update_lecture(){
         $assignedwork = $assignedwork + ($endTime - $time);
            
         //insert records depending on weeks number
-        for ($j=0;$j<=16;$j++){
+        for ($j=0;$j<=$weeks-1;$j++){
             $d = new DateTime($date);
             //adds record to selected week, next loop adds to next week etc...
             $d->modify('+'.$j.' weeks');

--- a/lecturesFunctions.php
+++ b/lecturesFunctions.php
@@ -172,17 +172,6 @@ function utt_create_lectures_page(){
             <?php _e("End time:","UniTimetable"); ?><br/>
             <input name="endTime" id="endTime" class="dirty" value="10:00" size="10"/>
         </div>
-        <div class="element weekDiv">
-            <?php _e("Number of weeks:","UniTimetable"); ?><br/>
-            <select name="weeks" id="weeks" class="dirty">
-                <?php
-                for( $i=1 ; $i<26 ; $i++ ){
-                    echo "<option value='$i'>$i</option>";
-                }
-                ?>
-            </select>
-        </div>
-            
             
             <div id="secondaryButtonContainer">
                 <input type="submit" value="<?php _e("Submit","UniTimetable"); ?>" id="insert-updateLecture" class="button-primary"/>
@@ -339,7 +328,7 @@ function utt_insert_update_lecture(){
         $assignedwork = $assignedwork + ($endTime - $time);
            
         //insert records depending on weeks number
-        for ($j=0;$j<=$weeks-1;$j++){
+        for ($j=0;$j<=16;$j++){
             $d = new DateTime($date);
             //adds record to selected week, next loop adds to next week etc...
             $d->modify('+'.$j.' weeks');

--- a/lecturesFunctions.php
+++ b/lecturesFunctions.php
@@ -107,7 +107,7 @@ function utt_create_lectures_page(){
         <?php _e("Group:","UniTimetable"); ?><br/>
         <div id="groups">
                     <!-- place groups when subject selected -->
-                    <select name="group" id="group" class="dirty">
+                    <select name="group" id="group" class="dirty" onchange="loadTheTeacher();">
             <option value="0"><?php _e("- select -","UniTimetable"); ?></option>
                     </select>
         </div>
@@ -116,14 +116,7 @@ function utt_create_lectures_page(){
         <div class="element firstInRow">
             <?php _e("Teacher:","UniTimetable"); ?><br/>
             <select name="teacher" id="teacher" class="dirty" onchange="loadWorkHours();">
-                <?php
-                $teachersTable=$wpdb->prefix."utt_teachers";
-                $teachers = $wpdb->get_results( "SELECT * FROM $teachersTable ORDER BY surname, name");
-                echo "<option value='0'>".__("- select -","UniTimetable")."</option>";
-                foreach($teachers as $teacher){
-                    echo "<option value='$teacher->teacherID'>$teacher->surname $teacher->name</option>";
-                }
-                ?>
+                <option value="0"><?php _e("- select -","UniTimetable"); ?></option>
             </select>
         </div>
         <div class="element">
@@ -231,7 +224,7 @@ function utt_load_groups(){
     $groupsTable = $wpdb->prefix."utt_groups";
     $safeSql = $wpdb->prepare("SELECT * FROM $groupsTable WHERE periodID=%d AND subjectID=%d ORDER BY groupName;",$period,$subject);
     $groups = $wpdb->get_results($safeSql);
-    echo "<select name='group' id='group' class='dirty'>";
+    echo "<select name='group' id='group' class='dirty' onchange='loadTheTeacher();'>";
     echo "<option value='0'>".__("- select -","UniTimetable")."</option>";
     foreach($groups as $group){
         //choose group selected when edit
@@ -275,6 +268,23 @@ function utt_load_subjects(){
     }
     echo "</select>";
     die();
+}
+//load teachers when group and subject is selected
+add_action('wp_ajax_utt_load_teachers', 'utt_load_teachers');
+function utt_load_teachers(){
+    global $wpdb;
+    $teachersTable=$wpdb->prefix."utt_teachers";
+    $sub=$_GET['teacherSubject'];
+    $grp=$_GET['teacherGroup'];
+    $safeSql = $wpdb->prepare("SELECT * FROM $teachersTable WHERE subjectID='$sub' AND groupID='$grp';");
+    $teachers = $wpdb->get_results($safeSql);
+    
+    echo "<select name='teacher' id='teacher' class='dirty' onchange='loadWorkHours();'>";
+    echo "<option value='0'>".__("- select -","UniTimetable")."</option>";
+    foreach($teachers as $teacher){
+        echo "<option value='$teacher->teacherID'>$teacher->surname $teacher->name</option>";
+    }
+    echo "</select>";
 }
 
 //load working hours when teacher is selected

--- a/teachersFunctions.php
+++ b/teachersFunctions.php
@@ -96,6 +96,7 @@ function utt_view_teachers(){
     $teachersTable=$wpdb->prefix."utt_teachers";
     $subjectsTable = $wpdb->prefix."utt_subjects";
     $groupsTable = $wpdb->prefix."utt_groups";
+    $teacherSubGrp=$wpdb->prefix."utt_teacher_sub_grp";
     //show registered teachers
     $teachers = $wpdb->get_results("SELECT * FROM $teachersTable ORDER BY surname");
     ?>
@@ -140,9 +141,11 @@ function utt_view_teachers(){
                 $bgcolor = 1;
             }
             //a record
-            $safeSql = $wpdb->prepare("SELECT * FROM $subjectsTable WHERE subjectID=%d",$teacher->subjectID);
+            $safeSql = $wpdb->prepare("SELECT * FROM $teacherSubGrp WHERE teacherID=%d",$teacher->teacherID);
+            $te = $wpdb->get_row($safeSql);
+            $safeSql = $wpdb->prepare("SELECT * FROM $subjectsTable WHERE subjectID=%d",$te->subjectID);
             $subject = $wpdb->get_row($safeSql);
-            $safeSql = $wpdb->prepare("SELECT * FROM $groupsTable WHERE groupID=%d",$teacher->groupID);
+            $safeSql = $wpdb->prepare("SELECT * FROM $groupsTable WHERE groupID=%d",$te->groupID);
             $group = $wpdb->get_row($safeSql);
 
             echo "<tr id='$teacher->teacherID' $addClass><td>$teacher->teacherID</td><td>$teacher->surname</td><td>$teacher->name</td><td>$teacher->minWorkLoad</td><td>$teacher->maxWorkLoad</td><td>$teacher->assignedWorkLoad</td><td>$subject->title</td> <td>$group->groupName</td> <td><a href='#' onclick='deleteTeacher($teacher->teacherID);' class='deleteTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/delete_icon.png', __FILE__)."'/> ".__("Delete","UniTimetable")."</a>&nbsp; <a href='#' onclick=\"editTeacher($teacher->teacherID, '$teacher->surname', '$teacher->name', $teacher->minWorkLoad, $teacher->maxWorkLoad);\" class='editTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/edit_icon.png', __FILE__)."'/> ".__("Edit","UniTimetable")."</a></td></tr>";
@@ -180,10 +183,17 @@ function utt_insert_update_teacher(){
     $teacherSubject=$_GET['teacher_subject_id'];
     $teacherGroup=$_GET['teacher_group_id'];
     $teachersTable=$wpdb->prefix."utt_teachers";
+    $teacherSubGrp=$wpdb->prefix."utt_teacher_sub_grp";
     //insert
     if($teacherid==0){
-        $safeSql = $wpdb->prepare("INSERT INTO $teachersTable (name, surname, minWorkLoad, maxWorkLoad, assignedWorkLoad, subjectID, groupID) VALUES (%s,%s,%d,%d,0,%d,%d)",$firstname,$lastname,$minhour,$maxhour,$teacherSubject,$teacherGroup);
+        $safeSql = $wpdb->prepare("INSERT INTO $teachersTable (name, surname, minWorkLoad, maxWorkLoad, assignedWorkLoad) VALUES (%s,%s,%d,%d,0)",$firstname,$lastname,$minhour,$maxhour);
         $success = $wpdb->query($safeSql);
+        
+        $safeSql = $wpdb->prepare("SELECT * FROM $teachersTable WHERE name=%s AND surname=%s",$firstname, $lastname);
+        $ans = $wpdb->get_row($safeSql);
+        echo $and->teacherID;
+        $safeSql = $wpdb->prepare("INSERT INTO $teacherSubGrp (teacherID, subjectID, groupID) VALUES (%d,%d,%d)", $ans->teacherID, $teacherSubject, $teacherGroup);
+        $wpdb->query($safeSql);
         if($success == 1){
             //success
             echo 1;
@@ -195,6 +205,11 @@ function utt_insert_update_teacher(){
     }else{
         $safeSql = $wpdb->prepare("UPDATE $teachersTable SET name=%s, surname=%s, minWorkLoad=%d, maxWorkLoad=%d subjectID=%d, groupID=%d WHERE teacherID=%d; ",$firstname,$lastname,$minhour,$maxhour,$teacherSubject,$teacherGroup,$teacherid);
         $success = $wpdb->query($safeSql);
+
+
+        $safeSql = $wpdb->prepare("UPDATE $teacherSubGrp SET subjectID=%d, groupID=%d WHERE teacherID=%d", $teacherSubject, $teacherGroup, $teacherid);
+        $wpdb->query($safeSql);
+       
         if($success == 1){
             //success
             echo 1;

--- a/teachersFunctions.php
+++ b/teachersFunctions.php
@@ -36,7 +36,7 @@ function utt_create_teachers_page(){
         <input type="text" name="lastname" id="lastname" class="dirty" required placeholder="<?php _e("Required","UniTimetable"); ?>"/>
         <br/>
         <?php _e("Name:","UniTimetable"); ?><br/>
-        <input type="text" name="firstname" id="firstname" class="dirty"/>
+        <input type="text" name="firstname" id="firstname" class="dirty" required placeholder="<?php _e("Required","UniTimetable"); ?>"/>
         <br/>
         <?php _e("Minimum workload:","UniTimetable"); ?><br/>
         <input type="text" name="minwork" id="minwork" class="dirty" required placeholder="<?php _e("Required","UniTimetable"); ?>"/>
@@ -44,6 +44,36 @@ function utt_create_teachers_page(){
         <?php _e("Maximum workload:","UniTimetable"); ?><br/>
         <input type="text" name="maxwork" id="maxwork" class="dirty" required placeholder="<?php _e("Required","UniTimetable"); ?>"/>
         <br/>
+       
+        <?php _e("Subject:","UniTimetable"); ?><br/>
+        <select style="width:195px;" name="subject" id="subject" class="dirty">
+            <?php
+            //fill select with subjects
+            global $wpdb;
+            $subjectTable=$wpdb->prefix."utt_subjects";
+            $subjects = $wpdb->get_results( "SELECT * FROM $subjectTable");
+            echo "<option value='0'>".__("- select -","UniTimetable")."</option>";
+            foreach($subjects as $sub){
+                $subj = $sub->title;
+                echo "<option value='$sub->subjectID'>$subj</option>";
+            }
+            ?>
+        </select>
+        <br/>
+        <?php _e("Group:","UniTimetable"); ?><br/>
+        <select style="width:195px;" name="group" id="group" class="dirty">
+            <?php
+            //fill select with groups
+            global $wpdb;
+            $groupsTable=$wpdb->prefix."utt_groups";
+            $groups = $wpdb->get_results( "SELECT * FROM $groupsTable");
+            echo "<option value='0'>".__("- select -","UniTimetable")."</option>";
+            foreach($groups as $grp){
+                echo "<option value='$grp->groupID'>$grp->groupName</option>";
+            }
+            ?>
+        </select>
+
         <div id="secondaryButtonContainer">
         <input type="submit" value="<?php _e("Submit","UniTimetable"); ?>" id="insert-updateTeacher" class="button-primary"/>
         <a href='#' class='button-secondary' id="clearTeacherForm"><?php _e("Reset","UniTimetable"); ?></a>
@@ -64,7 +94,8 @@ add_action('wp_ajax_utt_view_teachers', 'utt_view_teachers');
 function utt_view_teachers(){
     global $wpdb;
     $teachersTable=$wpdb->prefix."utt_teachers";
-        
+    $subjectsTable = $wpdb->prefix."utt_subjects";
+    $groupsTable = $wpdb->prefix."utt_groups";
     //show registered teachers
     $teachers = $wpdb->get_results("SELECT * FROM $teachersTable ORDER BY surname");
     ?>
@@ -78,6 +109,8 @@ function utt_view_teachers(){
                     <th><?php _e("Min workload","UniTimetable"); ?></th>
                     <th><?php _e("Max workload","UniTimetable"); ?></th>
                     <th><?php _e("Assigned workload","UniTimetable"); ?></th>
+                    <th><?php _e("Subject", "UniTimetable"); ?></th>
+                    <th><?php _e("Group", "UniTimetable"); ?></th>
                     <th><?php _e("Actions","UniTimetable"); ?></th>
                 </tr>
             </thead>
@@ -89,6 +122,8 @@ function utt_view_teachers(){
                     <th><?php _e("Min workload","UniTimetable"); ?></th>
                     <th><?php _e("Max workload","UniTimetable"); ?></th>
                     <th><?php _e("Assigned workload","UniTimetable"); ?></th>
+                    <th><?php _e("Subject", "UniTimetable"); ?></th>
+                    <th><?php _e("Group", "UniTimetable"); ?></th>
                     <th><?php _e("Actions","UniTimetable"); ?></th>
                 </tr>
             </tfoot>
@@ -105,7 +140,12 @@ function utt_view_teachers(){
                 $bgcolor = 1;
             }
             //a record
-            echo "<tr id='$teacher->teacherID' $addClass><td>$teacher->teacherID</td><td>$teacher->surname</td><td>$teacher->name</td><td>$teacher->minWorkLoad</td><td>$teacher->maxWorkLoad</td><td>$teacher->assignedWorkLoad</td><td><a href='#' onclick='deleteTeacher($teacher->teacherID);' class='deleteTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/delete_icon.png', __FILE__)."'/> ".__("Delete","UniTimetable")."</a>&nbsp; <a href='#' onclick=\"editTeacher($teacher->teacherID, '$teacher->surname', '$teacher->name', $teacher->minWorkLoad, $teacher->maxWorkLoad);\" class='editTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/edit_icon.png', __FILE__)."'/> ".__("Edit","UniTimetable")."</a></td></tr>";
+            $safeSql = $wpdb->prepare("SELECT * FROM $subjectsTable WHERE subjectID=%d",$teacher->subjectID);
+            $subject = $wpdb->get_row($safeSql);
+            $safeSql = $wpdb->prepare("SELECT * FROM $groupsTable WHERE groupID=%d",$teacher->groupID);
+            $group = $wpdb->get_row($safeSql);
+
+            echo "<tr id='$teacher->teacherID' $addClass><td>$teacher->teacherID</td><td>$teacher->surname</td><td>$teacher->name</td><td>$teacher->minWorkLoad</td><td>$teacher->maxWorkLoad</td><td>$teacher->assignedWorkLoad</td><td>$subject->title</td> <td>$group->groupName</td> <td><a href='#' onclick='deleteTeacher($teacher->teacherID);' class='deleteTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/delete_icon.png', __FILE__)."'/> ".__("Delete","UniTimetable")."</a>&nbsp; <a href='#' onclick=\"editTeacher($teacher->teacherID, '$teacher->surname', '$teacher->name', $teacher->minWorkLoad, $teacher->maxWorkLoad);\" class='editTeacher'><img id='edit-delete-icon' src='".plugins_url('icons/edit_icon.png', __FILE__)."'/> ".__("Edit","UniTimetable")."</a></td></tr>";
         }
         
         ?>
@@ -137,10 +177,12 @@ function utt_insert_update_teacher(){
     $teacherid=$_GET['teacher_id'];
     $maxhour=$_GET['teacher_max_work'];
     $minhour=$_GET['teacher_min_work'];
+    $teacherSubject=$_GET['teacher_subject_id'];
+    $teacherGroup=$_GET['teacher_group_id'];
     $teachersTable=$wpdb->prefix."utt_teachers";
     //insert
     if($teacherid==0){
-        $safeSql = $wpdb->prepare("INSERT INTO $teachersTable (name, surname, minWorkLoad, maxWorkLoad, assignedWorkLoad) VALUES (%s,%s,%d,%d,0)",$firstname,$lastname,$minhour,$maxhour);
+        $safeSql = $wpdb->prepare("INSERT INTO $teachersTable (name, surname, minWorkLoad, maxWorkLoad, assignedWorkLoad, subjectID, groupID) VALUES (%s,%s,%d,%d,0,%d,%d)",$firstname,$lastname,$minhour,$maxhour,$teacherSubject,$teacherGroup);
         $success = $wpdb->query($safeSql);
         if($success == 1){
             //success
@@ -151,7 +193,7 @@ function utt_insert_update_teacher(){
         }
     //edit
     }else{
-        $safeSql = $wpdb->prepare("UPDATE $teachersTable SET name=%s, surname=%s, minWorkLoad=%d, maxWorkLoad=%d WHERE teacherID=%d; ",$firstname,$lastname,$minhour,$maxhour,$teacherid);
+        $safeSql = $wpdb->prepare("UPDATE $teachersTable SET name=%s, surname=%s, minWorkLoad=%d, maxWorkLoad=%d subjectID=%d, groupID=%d WHERE teacherID=%d; ",$firstname,$lastname,$minhour,$maxhour,$teacherSubject,$teacherGroup,$teacherid);
         $success = $wpdb->query($safeSql);
         if($success == 1){
             //success


### PR DESCRIPTION
The staff is now associated with subject and group.
Hence, when subject and group is selected, staffs teaching that combination will only appear.
This commit will close the issue #22.
